### PR TITLE
W&B Tables Integration

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -57,6 +57,8 @@ training:
         # You can save your model checkpoints as W&B Artifacts for model versioning.
         # Set the value to `true` to enable this feature.
         log_checkpoint: false
+        # Set the evaluation prediction report as W&B Tables.
+        log_tables: false
         # Specify other argument values that you want to pass to wandb.init(). Check out the documentation
         # at https://docs.wandb.ai/ref/python/init to see what arguments are available.
         # job_type: 'train'

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -57,8 +57,6 @@ training:
         # You can save your model checkpoints as W&B Artifacts for model versioning.
         # Set the value to `true` to enable this feature.
         log_checkpoint: false
-        # Set the evaluation prediction report as W&B Tables.
-        log_tables: false
         # Specify other argument values that you want to pass to wandb.init(). Check out the documentation
         # at https://docs.wandb.ai/ref/python/init to see what arguments are available.
         # job_type: 'train'

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -44,7 +44,7 @@ training:
     # Weights and Biases control, by default Weights and Biases (wandb) is disabled
     wandb:
         # Whether to use Weights and Biases Logger, (Default: false)
-        enabled: false
+        enabled: true
         # An entity is a username or team name where you're sending runs.
         # This is necessary if you want to log your metrics to a team account. By default
         # it will log the run to your user account.
@@ -54,6 +54,9 @@ training:
         # Experiment/ run name to be used while logging the experiment
         # under the project with wandb
         name: ${training.experiment_name}
+        # You can save your model checkpoints as W&B Artifacts for model versioning.
+        # Set the value to `true` to enable this feature.
+        log_checkpoint: true
         # Specify other argument values that you want to pass to wandb.init(). Check out the documentation
         # at https://docs.wandb.ai/ref/python/init to see what arguments are available.
         # job_type: 'train'

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -44,7 +44,7 @@ training:
     # Weights and Biases control, by default Weights and Biases (wandb) is disabled
     wandb:
         # Whether to use Weights and Biases Logger, (Default: false)
-        enabled: true
+        enabled: false
         # An entity is a username or team name where you're sending runs.
         # This is necessary if you want to log your metrics to a team account. By default
         # it will log the run to your user account.
@@ -56,7 +56,7 @@ training:
         name: ${training.experiment_name}
         # You can save your model checkpoints as W&B Artifacts for model versioning.
         # Set the value to `true` to enable this feature.
-        log_checkpoint: true
+        log_checkpoint: false
         # Specify other argument values that you want to pass to wandb.init(). Check out the documentation
         # at https://docs.wandb.ai/ref/python/init to see what arguments are available.
         # job_type: 'train'

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -144,6 +144,12 @@ class TrainerEvaluationLoopMixin(ABC):
 
                 reporter.postprocess_dataset_report()
 
+                # Log the prediction report as W&B Tables
+                if self.config.training.wandb.log_tables:
+                    self.logistics_callback.wandb_logger.log_prediction_report(
+                        reporter.report, reporter.current_datamodule.dataset_name
+                    )
+
             logger.info(f"Finished predicting. Loaded {loaded_batches}")
             logger.info(f" -- skipped {skipped_batches} batches.")
             self.model.train()

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -144,12 +144,6 @@ class TrainerEvaluationLoopMixin(ABC):
 
                 reporter.postprocess_dataset_report()
 
-                # Log the prediction report as W&B Tables
-                if self.config.training.wandb.log_tables:
-                    self.logistics_callback.wandb_logger.log_prediction_report(
-                        reporter.report, reporter.current_datamodule.dataset_name
-                    )
-
             logger.info(f"Finished predicting. Loaded {loaded_batches}")
             logger.info(f" -- skipped {skipped_batches} batches.")
             self.model.train()

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -584,7 +584,7 @@ class Checkpoint:
                 "Saving current checkpoint as W&B Artifacts for model versioning"
             )
             self.trainer.logistics_callback.wandb_logger.log_model_checkpoint(
-                current_ckpt_filepath, ckpt
+                current_ckpt_filepath
             )
 
         # Remove old checkpoints if max_to_keep is set

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -431,7 +431,6 @@ class WandbLogger:
         wandb_kwargs.pop("entity")
         wandb_kwargs.pop("project")
         wandb_kwargs.pop("log_checkpoint")
-        wandb_kwargs.pop("log_tables")
         self._wandb_init.update(**wandb_kwargs)
 
         self.setup()
@@ -492,22 +491,3 @@ class WandbLogger:
 
         model_artifact.add_file(model_path, name="current.pt")
         self._wandb.log_artifact(model_artifact, aliases=["latest"])
-
-    def log_prediction_report(self, report, dataset_name):
-        """
-        Log the prediction report as W&B Tables for better comparison.
-
-        Args:
-            report: Prediction report to log.
-            dataset_name: Name of the dataset.
-        """
-        if not self._should_log_wandb():
-            return
-
-        columns = list(report[0].keys())
-        data_at = self._wandb.Table(columns=columns)
-
-        for item in report:
-            data_at.add_data(*item.values())
-
-        self._wandb.log({f"pred_table_{dataset_name}": data_at})

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -431,6 +431,7 @@ class WandbLogger:
         wandb_kwargs.pop("entity")
         wandb_kwargs.pop("project")
         wandb_kwargs.pop("log_checkpoint")
+        wandb_kwargs.pop("log_tables")
         self._wandb_init.update(**wandb_kwargs)
 
         self.setup()
@@ -491,3 +492,22 @@ class WandbLogger:
 
         model_artifact.add_file(model_path, name="current.pt")
         self._wandb.log_artifact(model_artifact, aliases=["latest"])
+
+    def log_prediction_report(self, report, dataset_name):
+        """
+        Log the prediction report as W&B Tables for better comparison.
+
+        Args:
+            report: Prediction report to log.
+            dataset_name: Name of the dataset.
+        """
+        if not self._should_log_wandb():
+            return
+
+        columns = list(report[0].keys())
+        data_at = self._wandb.Table(columns=columns)
+
+        for item in report:
+            data_at.add_data(*item.values())
+
+        self._wandb.log({f"pred_table_{dataset_name}": data_at})

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import collections
+import copy
 import functools
 import json
 import logging
@@ -429,11 +430,12 @@ class WandbLogger:
 
         self._wandb_init = dict(entity=entity, config=config, project=project)
 
-        wandb_params = config.training.wandb
+        wandb_params = copy.copy(config.training.wandb)
         with omegaconf.open_dict(wandb_params):
             wandb_params.pop("enabled")
             wandb_params.pop("entity")
             wandb_params.pop("project")
+            wandb_params.pop("log_checkpoint")
 
         init_kwargs = OmegaConf.to_container(wandb_params, resolve=True)
         self._wandb_init.update(**init_kwargs)
@@ -479,3 +481,21 @@ class WandbLogger:
             return
 
         self._wandb.log(metrics, commit=commit)
+
+    def log_model_checkpoint(self, model_path, ckpt_dict):
+        """
+        Log the model checkpoint to the wandb dashboard.
+
+        Args:
+            model_path (str): Path to the model file.
+            ckpt_dict (Dict[str, Any]): Checkpoint dictionary.
+        """
+        if not self._should_log_wandb():
+            return
+
+        model_artifact = self._wandb.Artifact(
+            "run_" + self._wandb.run.id + "_model", type="model"
+        )
+
+        model_artifact.add_file(model_path, name="current.pt")
+        self._wandb.log_artifact(model_artifact, aliases=["latest"])


### PR DESCRIPTION
The following is how I see it progressing, which might change in the future. 

- [x] Log the prediction report as W&B Tables. The current solution is generic in my opinion. 

![image](https://user-images.githubusercontent.com/31141479/141031915-079b3d83-a7ec-4ec1-8007-c7103d503753.png)

- [ ] Add ground truth answer for `textvqa` dataset and check for `use_image`.
- [ ] Add ability to log media. 
